### PR TITLE
nginx.conf: drop ADDIN_HOST substitution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,7 +104,6 @@ dist
 .tern-port
 
 # configuration files
-nginx.conf
 manifest.xml
 src/config.js
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm run build
 
 FROM nginx:latest
 COPY --from=build /app/dist /usr/share/nginx/html
-COPY nginx.conf.template /etc/nginx/conf.d/default.conf.template
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -12,21 +12,10 @@ window.config = {
 };
 ```
 
-## Nginx config template
-```
-server {
-    listen 80;
-    server_name ${ADDIN_HOST};
-    root /usr/share/nginx/html;
-    index taskpane.html taskpane.htm;
-}
-```
-
 ## Entrypoint.sh
 ```
 envsubst < /usr/share/nginx/html/manifest.xml.template > /usr/share/nginx/html/manifest.xml
 envsubst < /usr/share/nginx/html/config.js.template > /usr/share/nginx/html/config.js
-envsubst < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 
 nginx -g "daemon off;"
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,5 @@
 
 envsubst < /usr/share/nginx/html/manifest.xml.template > /usr/share/nginx/html/manifest.xml
 envsubst < /usr/share/nginx/html/config.js.template > /usr/share/nginx/html/config.js
-envsubst < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 
 nginx -g "daemon off;"

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,6 @@
 server {
-    listen 80;
-    server_name ${ADDIN_HOST};
+    listen 80 default_server;
+    server_name "";
     root /usr/share/nginx/html;
     index taskpane.html taskpane.htm;
 }


### PR DESCRIPTION
Use the `listen 80 default_server;` directive to match on all hostnames.

This will cause nginx to reply to all requests, no matter which `Host` is used in the request header.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

_Briefly describe the issue you have solved or implemented with this pull request. If the PR contains multiple issues, use a bullet list._

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
