### PR TITLE
fix: deleted defaultSubjectValue

### DIFF
--- a/src/calendarIntegration/addMeetingLink.ts
+++ b/src/calendarIntegration/addMeetingLink.ts
@@ -9,7 +9,6 @@ import { mailboxItem } from "../commands/commands";
 import { EventResult } from "../types/EventResult";
 import { PlatformType } from "../types/PlatformTypes";
 
-const defaultSubjectValue = "New Appointment";
 let createdMeeting: EventResult;
 
 /**
@@ -80,7 +79,7 @@ async function createNewMeeting(): Promise<void> {
   let subject = await getMailboxItemSubject(mailboxItem);
   subject = await modifyConversationName(subject);
 
-  const eventResult = await createEvent(subject || defaultSubjectValue);
+  const eventResult = await createEvent(subject);
 
   if (eventResult) {
     createdMeeting = eventResult;


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors


# What's new in this PR?

### Issues

"New Appointment" overwrites the "CLDR::" Prefix on empty conversation titles

### Solutions

Deleted defaultSubjectValue = "New Appointment";

### Testing

#### How to Test

Create a meeting without a title, and check for the CLDR:: "Current Date" conversation Title in Wire


#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
