### PR TITLE
fix: fixed slider and classic desktop application

### DIFF
--- a/manifest.xml.template
+++ b/manifest.xml.template
@@ -96,15 +96,6 @@
             </OfficeTab>
           </ExtensionPoint>
 
-          <!-- Enable launching the add-in on the included event. -->
-          <ExtensionPoint xsi:type="LaunchEvent">
-            <LaunchEvents>
-              <LaunchEvent Type="OnAppointmentSend" FunctionName="onAppointmentSendHandler" SendMode="PromptUser" />
-            </LaunchEvents>
-            <!-- Identifies the runtime to be used (also referenced by the Runtime element). -->
-            <SourceLocation resid="WebViewRuntime.Url"/>
-          </ExtensionPoint>
-
         </DesktopFormFactor>
         
         <MobileFormFactor>
@@ -159,10 +150,6 @@
         <bt:String id="TaskpaneButton.Tooltip" DefaultValue="Opens a pane displaying all available properties."/>
       </bt:LongStrings>
     </Resources>
-    <!-- Configure the prepend-on-send or append-on-send feature using the AppendOnSend value. -->
-    <ExtendedPermissions>
-      <ExtendedPermission>AppendOnSend</ExtendedPermission>
-    </ExtendedPermissions>
   </VersionOverrides>
 </VersionOverrides>
 </OfficeApp>

--- a/src/calendarIntegration/addMeetingLink.ts
+++ b/src/calendarIntegration/addMeetingLink.ts
@@ -7,7 +7,6 @@ import { isOutlookCalIntegrationEnabled } from "./isOutlookCalIntegrationEnabled
 import { createEvent } from "./createEvent";
 import { mailboxItem } from "../commands/commands";
 import { EventResult } from "../types/EventResult";
-import { PlatformType } from "../types/PlatformTypes";
 
 let createdMeeting: EventResult;
 
@@ -171,10 +170,7 @@ async function addMeetingLink(event: Office.AddinCommands.Event): Promise<void> 
     console.error("Error during adding Wire meeting link", error);
     handleAddMeetingLinkError(error);
   } finally {
-    if (isMobileDevice()) {
-      await appendToBody(mailboxItem, ""); //Workaround for mobile devices - Without body gets removed
-    }
-    event.completed();
+    event.completed( { allowEvent: true } );
   }
 }
 

--- a/src/utils/mailbox.ts
+++ b/src/utils/mailbox.ts
@@ -139,15 +139,4 @@ export async function setLocation(item, meetlingLink) {
     }
   });
 
-  if (isMobileDevice()) {
-    /* Workaround for mobile devices - sometimes location gets removed*/
-    let currentLocation = await getLocation(item);
-
-    location.setAsync(currentLocation + "", function (asyncResult) {
-      if (asyncResult.status !== Office.AsyncResultStatus.Succeeded) {
-        console.error(`Action failed with message ${asyncResult.error.message}`);
-        return;
-      }
-    });
-  }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

# What's new in this PR?

### Issues

Slider deactivates on mobile after activating it
Add-in is "crashing" on classic outlook desktop after sending the invitation. 

### Solutions

Fixed the event completion and removed the EventListener from manifest template

#### How to Test

Create a Meeting Link on Mobile and look at the Wire Slider.
Send a invitation link in outlook classic to check that the outlook add-in does not crash anymore. 

##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
