### PR TITLE
fix: fixed notfication error, added recreating of conversation in spe…

### DIFF
--- a/src/calendarIntegration/addMeetingLink.ts
+++ b/src/calendarIntegration/addMeetingLink.ts
@@ -158,19 +158,39 @@ async function handleExistingMeeting(): Promise<void> {
 async function addMeetingLink(event: Office.AddinCommands.Event): Promise<void> {
   try {
     const isEnabled = await isFeatureEnabled();
-    if (!isEnabled) return;
+    if (!isEnabled) {
+      return;
+    }
 
     await fetchCustomProperties();
+
     if (!createdMeeting) {
-      await createNewMeeting();
+      if (isMobileDevice()) {
+        const currentLocation = await getLocation(mailboxItem);
+        const currentBody = await getBody(mailboxItem);
+
+        const wireInvitationString = "https://account.anta.wire.link/conversation-join/";
+
+        //In some cases the wire invitation link is still present in location after deactiving the addin on mobile, so we can check for it and reuse it.
+        if (currentLocation.toString().includes(wireInvitationString) && !currentBody.includes(wireInvitationString)) {
+          const organizer = await getPlatformSpecificOrganizer();
+          const meetingSummary = createMeetingSummary(currentLocation, organizer);
+          await appendToBody(mailboxItem, meetingSummary);
+        } else if (currentLocation.toString().includes(wireInvitationString)) {
+          return;
+        } else {
+          await createNewMeeting();
+        }
+      } else {
+        await createNewMeeting();
+      }
     } else {
       await handleExistingMeeting();
     }
   } catch (error) {
-    console.error("Error during adding Wire meeting link", error);
     handleAddMeetingLinkError(error);
   } finally {
-    event.completed( { allowEvent: true } );
+    event.completed({ allowEvent: true });
   }
 }
 

--- a/src/calendarIntegration/addMeetingLink.ts
+++ b/src/calendarIntegration/addMeetingLink.ts
@@ -169,7 +169,8 @@ async function addMeetingLink(event: Office.AddinCommands.Event): Promise<void> 
         const currentLocation = await getLocation(mailboxItem);
         const currentBody = await getBody(mailboxItem);
 
-        const wireInvitationString = "https://account.anta.wire.link/conversation-join/";
+        //Needs to be changed if the wire invitation string changes in future
+        const wireInvitationString = "/conversation-join/?key=";
 
         //In some cases the wire invitation link is still present in location after deactiving the addin on mobile, so we can check for it and reuse it.
         if (currentLocation.toString().includes(wireInvitationString) && !currentBody.includes(wireInvitationString)) {

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,28 +1,34 @@
 /* global Office, console */
 
-export function showNotification(key, message, type, icon = null, persistent = null) {
-  const notificationMessage = {
-    type,
-    icon,
-    message,
-    persistent,
-  };
+import { isMobileDevice } from "./mailbox";
 
-  Office.context.mailbox.item.notificationMessages.addAsync(key, notificationMessage, (result) => {
-    if (result.status === Office.AsyncResultStatus.Succeeded) {
-      console.log(`Notification with key "${key}" added successfully.`);
-    } else {
-      console.error("Failed to add notification message:", result.error);
-    }
-  });
+export function showNotification(key, message, type, icon = null, persistent = null) {
+  if(!isMobileDevice()){
+    const notificationMessage = {
+      type,
+      icon,
+      message,
+      persistent,
+    };
+
+    Office.context.mailbox.item.notificationMessages.addAsync(key, notificationMessage, (result) => {
+      if (result.status === Office.AsyncResultStatus.Succeeded) {
+        console.log(`Notification with key "${key}" added successfully.`);
+      } else {
+        console.error("Failed to add notification message:", result.error);
+      }
+    });
+  }
 }
 
 export function removeNotification(key) {
-  Office.context.mailbox.item.notificationMessages.removeAsync(key, (result) => {
-    if (result.status === Office.AsyncResultStatus.Succeeded) {
-      console.log(`Notification with key "${key}" removed successfully.`);
-    } else {
-      console.error("Failed to remove notification:", result.error);
-    }
-  });
+  if(!isMobileDevice()){
+    Office.context.mailbox.item.notificationMessages.removeAsync(key, (result) => {
+      if (result.status === Office.AsyncResultStatus.Succeeded) {
+        console.log(`Notification with key "${key}" removed successfully.`);
+      } else {
+        console.error("Failed to remove notification:", result.error);
+      }
+    });
+  }
 }


### PR DESCRIPTION
…cial cases

----
#### PR Submission Checklist for internal contributors

# What's new in this PR?

### Issues

Removed notifications from mobile devices, because they are not supported.
In some cases on mobile after deactivating the wire add-in slider (for example by mistake) the location still persist, so it can be used to recreate the conversation without generating a new one. 

### Solutions

Improved the notification with a check for mobile devices.
Checking if the current platform is mobile, the location have a wire link and the body is empty. 

### Testing

#### How to Test

Sideload the app on mobile and activate/deactivate the add-in for a few times.

##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
